### PR TITLE
Update platform interface for working with app-tools 0.5

### DIFF
--- a/lib/DebProject.js
+++ b/lib/DebProject.js
@@ -9,15 +9,14 @@ var Shell = require ("shelljs");
 var Path = require ('path');
 var SDK = require ('./DebSDK');
 
-function DebPlatform(PlatformBase, baseData, args) {
+function DebPlatform(PlatformBase, baseData) {
     /**
      * Interface for project implementations.
      * @constructor
      * @protected
      */
-    function DebProject(PlatformBase, baseData, args) {
+    function DebProject(PlatformBase, baseData) {
         PlatformBase.call(this, baseData);
-        this.sign = args.sign || '';
         Console = console;
     }
 
@@ -40,8 +39,8 @@ function DebPlatform(PlatformBase, baseData, args) {
      * @abstract
      * @memberOf Project
      */
-    DebProject.prototype.generate =
-        function(options, callback) {
+    DebProject.prototype.create =
+        function(packageId, args, callback) {
 
             // TODO implement generation of project.
             Console.log("DebProject: Generating " + this.packageId);
@@ -144,7 +143,7 @@ function DebPlatform(PlatformBase, baseData, args) {
      * @memberOf Project
      */
     DebProject.prototype.build =
-        function(abis, release, callback) {
+        function(configId, args, callback) {
 
             // TODO implement updating of project to new Crosswalk version.
             Console.log("DebProject: Building project");
@@ -170,22 +169,34 @@ function DebPlatform(PlatformBase, baseData, args) {
             
             var Manifest = require(Path.join(project_dir, 'www', 'manifest.json'));
             var options = {'path':project_dir, 'id': this.packageId};
-            if (this.sign.length > 0)
-                options.sign = this.sign;
+            if (args.sign.length > 0)
+                options.sign = args.sign;
             var sdk = new SDK(options);
             sdk.prepare(Manifest);
+
+            // TODO: configId is a string name of the configuration to
+            // build. Emulate old boolean "release" parameter here.
+            // Check if correct.
+            var release = configId === "release";
+
+            // TODO there could be args added in getArgs() if not all
+            // should be built.
+            var abis = ["i386", "X86_64"];
+
             sdk.build(abis, release);
             this.exportPackage(Shell.ls(Path.join(project_dir, 'build', project_name + '*.deb'))[0]);
             // Null means success, error string means failure.
             callback(null);
         };
 
-    return new DebProject(PlatformBase, baseData, args);
+    return new DebProject(PlatformBase, baseData);
 }
 
 DebPlatform.getArgs = function() {
     return {
-        'sign': "The sign GPG key."
+        build: {
+            sign: "The sign GPG key"
+        }
     };
 }
 


### PR DESCRIPTION
There have been changes in method names (generate -> create) and signatures. This makes the backend load with app-tools 0.5, but no testing has been done beyond that.
