### PR TITLE
Rewrite the launcher template script.

### DIFF
--- a/data/deb_template/template
+++ b/data/deb_template/template
@@ -1,12 +1,23 @@
-#!/bin/bash
+#!/bin/sh
 
-# Copyright © 2014 Intel Corporation. All rights reserved.
-# Use  of this  source  code is  governed by  an Apache v2
-# license that can be found in the LICENSE-APACHE-V2 file.
+# This file has been generated automatically. It is a generic wrapper
+# responsible for launching a Crosswalk-based application.
 
-CMD_PATH=$( realpath "$0" )
-DIR=$( cd "$( dirname "$CMD_PATH" )" && pwd )
-XWALK=$( which xwalk )
+which xwalk 2>&1 > /dev/null
 
-$XWALK ${DIR}/www/manifest.json
+if [ $? -ne 0 ]; then
+    echo "Error: cannot find the 'xwalk' executable."
+    echo "Please make sure Crosswalk is installed."
+    exit 1
+fi
 
+BASEDIR=$(dirname `readlink -f "$0"`)
+MANIFEST="${BASEDIR}/www/manifest.json"
+
+if [ ! -f "${MANIFEST}" ]; then
+    echo "Error: Cannot find ${MANIFEST}."
+    echo "Plase make sure the application has been installed correctly."
+    exit 1
+fi
+
+exec xwalk "${BASEDIR}/www/manifest.json"


### PR DESCRIPTION
Several small changes combined into one commit:
- Drop the copyright header. Not only is the script small, but it is
  shipped with any app that uses crosswalk-app-tools-deb. This means
  that the app would end up having a generic wrapper with an Intel
  copyright referencing a possibly non-existent license file in it.
- While at it, make it clear that this is a generic and auto-generated
  file.
- Use `/bin/sh` instead of `/bin/bash`. The script is portable enough not to
  require bash to run.
- Add some error checking so that we do not try to execute xwalk if it
  does not exist, or if the manifest is not present for some reason.
- Use exec to launch the Crosswalk binary so that we do not fork a new
  process from the script, but rather replace the current shell with it.
- Stop relying on `realpath(1)`. It is not always present on systems (for
  example, Debian < jessie and Ubuntu < 14.10 had it in a separate
  package that is not guaranteed to be installed). Instead, just use
  `readlink(1)` since it is part of GNU coreutils.

It is possible to further improve the script in the future: if we know
that the app is always going to be installed in a certain location,
there is no need to call readlink and determine the full path, for
example. The same goes for the xwalk binary.

BUG=XWALK-4537
