### PR TITLE
When I run UpgradeDeb, c_version contains a line feed

### DIFF
--- a/lib/DebSDK.js
+++ b/lib/DebSDK.js
@@ -36,6 +36,7 @@ DebSDK.prototype.UpgradeDeb = function (target_dir, version, manifest) {
     Shell.pushd(target_dir);
     // Upgrade version
     var c_version = Shell.exec(['dpkg-parsechangelog', '--show-field Version'].join(' '), {silent:true}).output;
+    c_version = c_version.trim();
     if (c_version != version) {
         Shell.exec(['dch -v', version, 'Upgrade'].join(' '));
     }


### PR DESCRIPTION
Remove line feed at the end of c_version. Otherwise it always differs from version.
